### PR TITLE
add general function to get tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/oras-project/oras-py/tree/main) (0.0.x)
+ - pagination for tags (and general function for pagination) (0.1.14)
  - expose upload_blob function to be consistent (0.1.13)
  - ensure we always strip path separators before pull/push (0.1.12)
  - exposing download_blob to the user since it uses streaming (0.1.11)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ FORCE_CLASSIC = FORCE_CLASSIC in ("1", "true")
 project = "Oras Python"
 html_title = "Oras Python"
 
-copyright = "2022, Oras Python Developers"
+copyright = "2023, Oras Python Developers"
 author = "@vsoch"
 
 # The full version, including alpha/beta/rc tags

--- a/oras/defaults.py
+++ b/oras/defaults.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
+__copyright__ = "Copyright The ORAS Authors"
 __license__ = "Apache-2.0"
 
 

--- a/oras/version.py
+++ b/oras/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright The ORAS Authors."
 __license__ = "Apache-2.0"
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "oras"


### PR DESCRIPTION
this extends the updated get tags function (with pagination!) to use a general function, so a future caller can use the same functionality. I also use the original request base url as the base for the updated parameters and this assumes the Link returned is at the same url. If we hit cases where this isn't the case, we should use the url provided by the link and add back onto it the domain. I think for most of these pagination cases the base url won't change, so this is OK as a first shot.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>